### PR TITLE
Updating Link in Homepage

### DIFF
--- a/src/components/DrawerComp.js
+++ b/src/components/DrawerComp.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState } from "react";
 import {
   Drawer,
   IconButton,
@@ -7,11 +7,12 @@ import {
   ListItemIcon,
   ListItemText,
 } from "@mui/material";
-import MenuIcon from "@mui/icons-material/Menu"
+import MenuIcon from "@mui/icons-material/Menu";
 
 const DrawerComp = () => {
-  const PAGES = ["About", "Events", "Socials", "Our Team"]
-  const [openDrawer, setOpenDrawer] = useState(false)
+  const PAGES = ["About", "Events", "Socials", "Our Team", "Opportunities"];
+  const PAGES_MAPPING = ["about", "events", "socials", "team", "opportunities"];
+  const [openDrawer, setOpenDrawer] = useState(false);
   return (
     <>
       <Drawer
@@ -21,7 +22,11 @@ const DrawerComp = () => {
       >
         <List>
           {PAGES.map((page, index) => (
-            <ListItemButton onClick={() => setOpenDrawer(false)} key={index}>
+            <ListItemButton
+              onClick={() => setOpenDrawer(false)}
+              key={index}
+              href={"/" + PAGES_MAPPING[index]}
+            >
               <ListItemIcon>
                 <ListItemText>{page}</ListItemText>
               </ListItemIcon>
@@ -37,4 +42,12 @@ const DrawerComp = () => {
   );
 };
 
-export default DrawerComp
+// {PAGES.map((page, index) => (
+//   <Tab
+//     key={index}
+//     label={page}
+//     href={"/" + PAGES_MAPPING[index]}
+//   ></Tab>
+// ))}
+
+export default DrawerComp;

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -1,15 +1,15 @@
 import {
   AppBar,
   Toolbar,
-  IconButton,
   Typography,
-  Stack,
   Button,
   Box,
   useMediaQuery,
   useTheme,
   Tabs,
   Tab,
+  Grid,
+  Link,
 } from "@mui/material";
 
 import { useSession, signIn, signOut } from "next-auth/react";
@@ -17,11 +17,11 @@ import React, { useState, useEffect } from "react";
 import DrawerComp from "./DrawerComp";
 
 // Navbar Pages
-const PAGES = ["About", "Events", "Socials", "Our Team"];
+const PAGES = ["About", "Events", "Socials", "Our Team", "Opportunities"];
 
 // This is overkill but, we want page -> href mapping w/ key-value
 // Index matches pages since lists retain position (index)
-const PAGES_MAPPING = ["about", "events", "socials", "team"];
+const PAGES_MAPPING = ["about", "events", "socials", "team", "opportunities"];
 
 const Navbar = (props) => {
   const { data: session, status } = useSession();
@@ -35,22 +35,61 @@ const Navbar = (props) => {
         <Toolbar>
           {isMatch ? (
             <>
-              <DrawerComp sx={{ marginLeft: 4 }} />
-              <Box
-                component="img"
-                sx={{ height: 50, width: 50, mx: "auto" }}
-                alt="Google Developer Student Club Logo"
-                src="/static/images/gdsc_logo.png"
-              />
+              <Grid
+                container
+                display="flex"
+                justifyContent="center"
+                alignItems="center"
+              >
+                <Grid item xs={2}>
+                  <DrawerComp sx={{ marginLeft: 4 }} />
+                </Grid>
+                <Grid item xs={8}>
+                  <Box
+                    display="flex"
+                    justifyContent="center"
+                    alignItems="center"
+                  >
+                    <a href="/">
+                      <img
+                        alt="Google Developer Student Club Logo"
+                        src="/static/images/gdsc_logo.png"
+                        height="50px"
+                        width="50px"
+                        marginX="auto"
+                      />
+                    </a>
+                  </Box>
+                </Grid>
+                <Grid item xs={2}>
+                  <div></div>
+                </Grid>
+              </Grid>
             </>
           ) : (
             <>
-              <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-                DSC KSU
+              <Typography
+                variant="h6"
+                noWrap
+                component={Link}
+                sx={{ flexGrow: 1, textDecoration: "none" }}
+              >
+                <Link
+                  href="/"
+                  underline="none"
+                  color={theme.palette.primary.alternate}
+                >
+                  DSC KSU
+                </Link>
               </Typography>
-              <Tabs textColor={ theme.palette.text.primary }>
+
+              <Tabs textColor={theme.palette.text.primary}>
                 {PAGES.map((page, index) => (
-                  <Tab key={index} label={page} href={('/'+PAGES_MAPPING[index])}></Tab>
+                  <Tab
+                    key={index}
+                    label={page}
+                    href={"/" + PAGES_MAPPING[index]}
+                  ></Tab>
                 ))}
               </Tabs>
 
@@ -79,4 +118,4 @@ const Navbar = (props) => {
   );
 };
 
-export default Navbar
+export default Navbar;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -117,7 +117,7 @@ export default function Index() {
           </Grid>
           {/*----Button-------*/}
           <Grid item>
-            <Button variant="contained" color="secondary">
+            <Button href="/about" variant="contained" color="secondary">
               Get Started
             </Button>
           </Grid>


### PR DESCRIPTION
Commit changes for Issue #41:
 - Link the GDSC logo direct to homepage.
 - Link `Get Started` button in homepage direct to `about` page
 
TODO:  
- [ ] Link the page href in drawer component (drawer navbar) 